### PR TITLE
Support custom restana initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ service.start(3000)
 ```js
 {
   // Optional restana library configuration (https://www.npmjs.com/package/restana#configuration)
+  // If the given value is a function instead of an object, it will be considered a restana service factory.
   restana: {},
   // Optional global middlewares in the format: (req, res, next) => next() 
   // Default value: []

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const gateway = (opts) => {
     pathRegex: '/*'
   }, opts)
 
-  const server = restana(opts.restana || {
+  const server = (opts.restana instanceof Function) ? opts.restana() : restana(opts.restana || {
     disableResponseEvent: true
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-gateway",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3208,9 +3208,9 @@
       }
     },
     "restana": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/restana/-/restana-3.3.3.tgz",
-      "integrity": "sha512-14e5/Ah2B27vKyu5ZN0eEYgtBoy1zcIrXbf2EoG20a6SEuPSJ35j+uE/xEplodaN0C0wWNiATdxhUnkgdI2TaA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/restana/-/restana-3.4.0.tgz",
+      "integrity": "sha512-pjlOIyEun2udD2lpRkXhOCgmgCblEYSBKKJsHZDqlEu/4r7LC3MGym9n5GC6aD7jI+lrk9JuGfsE0DCMemIYoA==",
       "requires": {
         "find-my-way": "^2.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-gateway",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A Node.js API Gateway for the masses!",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "dependencies": {
     "fast-proxy": "^1.3.0",
     "http-cache-middleware": "^1.2.3",
-    "restana": "^3.3.3",
+    "restana": "^3.4.0",
     "stream-to-array": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This extension allows to externalise the restana server instantiation: 
```js
const gateway = require('fast-gateway')
const restana = require('restana')
const serverInstance = restana({})

const server = gateway({
  restana: () => serverInstance,
  //...
})
```