### PR TITLE
Added Demo to support multiple hooks

### DIFF
--- a/demos/multiple-hooks.js
+++ b/demos/multiple-hooks.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const gateway = require('./../index')
+const PORT = process.env.PORT || 8080
+
+const { multipleHooks } = require('fg-multiple-hooks');
+
+const hook1 = async (req, res) => {
+    console.log('hook1 with logic 1 called');
+    // res.send('hook failed here');
+    return false; // do not abort the request
+};
+
+const hook2 = async (req, res) => {
+    console.log('hook2 with logic 2 called');
+    const shouldAbort = true;
+    if (shouldAbort) {
+        res.send('handle a rejected request here');
+    }
+    return shouldAbort; 
+}
+
+gateway({
+  routes: [{
+    prefix: '/service',
+    target: 'http://127.0.0.1:3000',
+    hooks: {
+        onRequest: (req, res) => multipleHooks(req, res, hook1, hook2), // you can add as many hooks as you please
+        onResponse (req, res, stream) {
+            // you can alter the origin response and remote response here
+            // default implementation explained here:
+            // https://www.npmjs.com/package/fast-gateway#onresponse-hook-default-implementation
+        }
+    }
+  }]
+}).start(PORT).then(server => {
+  console.log(`API Gateway listening on ${PORT} port!`)
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,11 @@ declare namespace fastgateway {
     type: string;
   }
 
+  interface Opts {
+    server?: Function,
+    middlewares?: Function[],
+    routes?: Route[], 
+  }
   interface Route {
     proxyType?: Type;
     fastProxy?: {};

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "express": "^4.17.1",
     "express-jwt": "^5.3.3",
     "express-rate-limit": "^5.1.3",
+    "fg-multiple-hooks": "^1.0.1",
     "helmet": "^3.22.0",
     "http-lambda-proxy": "^1.0.1",
     "mocha": "^7.2.0",


### PR DESCRIPTION
Hi again,

Added one definition (may need addition from your end like last time).

Also added support for multiple onRequest hooks.

(we are generating the config object programatically and there are scenarios where we would appreciate this functionality)

My first thought was to override the existing onRequest attribute of Hooks but then i thought it would break existing functionality