### PR TITLE
Support req query forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ module.exports.handler = serverless(service)
       //   // we can optionally reply from here if required
       //   res.end('Hello World!')
       //
+      //   // we can optionally update the request query params from here if required
+      //   req.query.category = 'js'
+      //
       //   return true // truthy value returned will abort the request forwarding
       },
       onResponse (req, res, stream) {  

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ const handler = (route, proxy, proxyHandler) => async (req, res, next) => {
       const proxyOpts = Object.assign({
         request: {
           timeout: req.timeout || route.timeout
-        }
+        },
+        queryString: req.query
       }, route.hooks)
 
       proxyHandler(req, res, req.url, proxy, proxyOpts)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@polka/send-type": "^0.5.2",
     "fast-proxy": "^1.7.0",
     "http-cache-middleware": "^1.3.5",
-    "restana": "^4.7.1",
+    "restana": "^4.7.3",
     "stream-to-array": "^2.3.0"
   },
   "files": [
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "aws-sdk": "^2.725.0",
+    "aws-sdk": "^2.742.0",
     "chai": "^4.2.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
@@ -50,7 +50,7 @@
     "fg-multiple-hooks": "1.2.0",
     "helmet": "^3.23.3",
     "http-lambda-proxy": "^1.0.1",
-    "mocha": "^8.1.0",
+    "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "opossum": "^4.2.4",
     "request-ip": "^2.1.3",

--- a/test/config.js
+++ b/test/config.js
@@ -75,6 +75,30 @@ module.exports = async () => {
     },
     {
       pathRegex: '',
+      prefix: '/qs',
+      prefixRewrite: '/qs',
+      target: 'http://localhost:3000',
+      methods: ['GET'],
+      hooks: {
+        onRequest: (req) => {
+          req.query.name = 'fast-gateway'
+        }
+      }
+    },
+    {
+      pathRegex: '',
+      prefix: '/qs2',
+      prefixRewrite: '/qs',
+      target: 'http://localhost:3000',
+      methods: ['GET'],
+      hooks: {
+        queryString: {
+          name: 'qs-overwrite'
+        }
+      }
+    },
+    {
+      pathRegex: '',
       prefix: '/endpoint-proxy-methods-put',
       prefixRewrite: '/endpoint-proxy-methods-put',
       target: 'http://localhost:3000',

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -58,9 +58,6 @@ describe('API Gateway', () => {
     remote.get('/qs', (req, res) => {
       res.send(req.query)
     })
-    remote.get('/qs2', (req, res) => {
-      res.send(req.query)
-    })
 
     await remote.start(3000)
   })

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -19,7 +19,7 @@ describe('API Gateway', () => {
       name: 'endpoint-proxy'
     }))
     remote.get('/info', (req, res) => res.send({
-      name: 'fastify-gateway'
+      name: 'fast-gateway'
     }))
     remote.get('/chunked', (req, res) => {
       res.write('user')
@@ -55,6 +55,12 @@ describe('API Gateway', () => {
     remote.post('/endpoint-proxy-methods', (req, res) => res.send({
       name: 'endpoint-proxy-methods'
     }))
+    remote.get('/qs', (req, res) => {
+      res.send(req.query)
+    })
+    remote.get('/qs2', (req, res) => {
+      res.send(req.query)
+    })
 
     await remote.start(3000)
   })
@@ -178,7 +184,7 @@ describe('API Gateway', () => {
       .get('/users/info')
       .expect(200)
       .then((response) => {
-        expect(response.body.name).to.equal('fastify-gateway')
+        expect(response.body.name).to.equal('fast-gateway')
       })
   })
 
@@ -302,6 +308,24 @@ describe('API Gateway', () => {
       .set('Connection', 'keep-alive')
       .then((res) => {
         expect(res.text).to.equal('user1')
+      })
+  })
+
+  it('GET /qs - 200', async () => {
+    await request(gateway)
+      .get('/qs')
+      .expect(200)
+      .then((response) => {
+        expect(response.body.name).to.equal('fast-gateway')
+      })
+  })
+
+  it('GET /qs2 - 200', async () => {
+    await request(gateway)
+      .get('/qs2?name=fast-gateway')
+      .expect(200)
+      .then((response) => {
+        expect(response.body.name).to.equal('qs-overwrite')
       })
   })
 


### PR DESCRIPTION
As described in: https://github.com/jkyberneees/fast-gateway/issues/47, we now forward the `req.query` object to the origin as query string if `queryString` parameter is not defined in `route.hooks`. 
This new feature will allow developers to easily update the request query parameters from inside the `onRequest` hook. 

Closes: https://github.com/jkyberneees/fast-gateway/issues/47