### PR TITLE
Supporting hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,56 @@ gateway({
 ```
 > In this example we have used the [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) module.
 
+## Hostnames support
+We can also implement hostnames support with fast-gateway, basically we translate hostnames to prefixes: 
+```js
+...
+
+// binding hostnames to prefixes
+const hostnames2prefix = [{
+  prefix: '/api',
+  hostname: 'api.company.tld'
+}]
+// instantiate hostnames hook, this will prefix request urls according to data in hostnames2prefix
+const hostnamesHook = require('fast-gateway/lib/hostnames-hook')(hostnames2prefix)
+
+// separately instantiate and configure restana application
+const app = restana()
+const server = http.createServer((req, res) => {
+  hostnamesHook(req, res, () => {
+    return app(req, res)
+  })
+})
+
+// gateway configuration
+gateway({
+  server: app, // injecting existing restana application
+  routes: [{
+    prefix: '/api',
+    target: 'http://localhost:3000'
+  }]
+})
+
+...
+```
+> Afterwards:  
+> `curl --header "Host: api.company.tld:8080" http://127.0.0.1:8080/api-service-endpoint`
+
+You can optionally `npm install micromatch` and benefit from patterns support:
+```js
+const hostnames2prefix = [{
+  prefix: '/admin',
+  hostname: '*.admin.company.tld'
+}, {
+  prefix: '/services',
+  hostname: [
+    'services.company.tld', 
+    '*.services.company.tld'
+  ]
+}]
+```
+For more details, please checkout the `basic-hostnames.js` demo.
+
 ## Gateway level caching
 Caching support is provided by the `http-cache-middleware` module. https://www.npmjs.com/package/http-cache-middleware
 

--- a/demos/basic-hostnames.js
+++ b/demos/basic-hostnames.js
@@ -7,8 +7,8 @@ const restana = require('restana')
 
 // binding hostnames to prefixes
 const hostnames2prefix = [{
-  prefix: '/public',
-  hostname: 'nodejs.org'
+  prefix: '/api',
+  hostname: 'api.company.tld'
 }]
 // instantiate hostnames hook, this will prefix request urls according to data in hostnames2prefix
 const hostnamesHook = require('./../lib/hostnames-hook')(hostnames2prefix)
@@ -28,7 +28,7 @@ gateway({
   ],
 
   routes: [{
-    prefix: '/public',
+    prefix: '/api',
     target: 'http://localhost:3000'
   }]
 })

--- a/demos/basic-hostnames.js
+++ b/demos/basic-hostnames.js
@@ -5,12 +5,15 @@ const PORT = process.env.PORT || 8080
 const http = require('http')
 const restana = require('restana')
 
+// binding hostnames to prefixes
 const hostnames2prefix = [{
   prefix: '/public',
   hostname: 'nodejs.org'
 }]
+// instantiate hostnames hook, this will prefix request urls according to data in hostnames2prefix
 const hostnamesHook = require('./../lib/hostnames-hook')(hostnames2prefix)
 
+// separately instantiate and configure restana application
 const app = restana()
 const server = http.createServer((req, res) => {
   hostnamesHook(req, res, () => {
@@ -18,8 +21,9 @@ const server = http.createServer((req, res) => {
   })
 })
 
+// gateway configuration
 gateway({
-  server: app,
+  server: app, // injecting existing restana application
   middlewares: [
   ],
 

--- a/demos/basic-hostnames.js
+++ b/demos/basic-hostnames.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const gateway = require('../index')
+const PORT = process.env.PORT || 8080
+const http = require('http')
+const restana = require('restana')
+
+const hostnames2prefix = [{
+  prefix: '/public',
+  hostname: 'nodejs.org'
+}]
+const hostnamesHook = require('./../lib/hostnames-hook')(hostnames2prefix)
+
+const app = restana()
+const server = http.createServer((req, res) => {
+  hostnamesHook(req, res, () => {
+    return app(req, res)
+  })
+})
+
+gateway({
+  server: app,
+  middlewares: [
+  ],
+
+  routes: [{
+    prefix: '/public',
+    target: 'http://localhost:3000'
+  }]
+})
+
+server.listen(PORT)
+
+const origin = require('restana')({})
+origin
+  .get('/hi', (req, res) => res.send('Hello World!'))
+  .start(3000)

--- a/lib/hostnames-hook.js
+++ b/lib/hostnames-hook.js
@@ -1,0 +1,40 @@
+'use strict'
+
+let micromatch
+try {
+  micromatch = require('micromatch')
+} catch (e) {
+  micromatch = {
+    isMatch (value, pattern) {
+      return value === pattern
+    }
+  }
+}
+
+module.exports = hostname2prefix => {
+  const matches = {}
+
+  return (req, res, cb) => {
+    if (req.headers.host) {
+      const hostHeader = req.headers.host.split(':')[0]
+      let prefix = matches[hostHeader]
+
+      if (!prefix) {
+        for (const e of hostname2prefix) {
+          if (micromatch.isMatch(hostHeader, e.hostname)) {
+            prefix = e.prefix
+            matches[hostHeader] = prefix
+
+            break
+          }
+        }
+      }
+
+      if (prefix) {
+        req.url = prefix + req.url
+      }
+    }
+
+    return cb()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "fg-multiple-hooks": "^1.2.0",
     "helmet": "^4.1.1",
     "http-lambda-proxy": "^1.0.1",
+    "micromatch": "^4.0.2",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "opossum": "^5.0.1",

--- a/test/hostnames-hook.test.js
+++ b/test/hostnames-hook.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+/* global describe, it */
+const expect = require('chai').expect
+
+describe('hostnames-hook', () => {
+  let hostnamesHook = null
+
+  it('initialize', async () => {
+    hostnamesHook = require('./../lib/hostnames-hook')([{
+      prefix: '/nodejs',
+      hostname: 'nodejs.org'
+    }, {
+      prefix: '/github',
+      hostname: 'github.com'
+    }, {
+      prefix: '/users',
+      hostname: '*.company.tld'
+    }])
+  })
+
+  it('is match - nodejs.org', (cb) => {
+    const req = {
+      headers: {
+        host: 'nodejs.org:443'
+      },
+      url: '/about'
+    }
+
+    hostnamesHook(req, null, () => {
+      expect(req.url).to.equal('/nodejs/about')
+      cb()
+    })
+  })
+
+  it('is match - github.com', (cb) => {
+    const req = {
+      headers: {
+        host: 'github.com:443'
+      },
+      url: '/about'
+    }
+
+    hostnamesHook(req, null, () => {
+      expect(req.url).to.equal('/github/about')
+      cb()
+    })
+  })
+
+  it('is match - wildcard', (cb) => {
+    const req = {
+      headers: {
+        host: 'kyberneees.company.tld:443'
+      },
+      url: '/about'
+    }
+
+    hostnamesHook(req, null, () => {
+      expect(req.url).to.equal('/users/about')
+      cb()
+    })
+  })
+
+  it('is not match - 404', (cb) => {
+    const req = {
+      headers: {
+        host: 'facebook.com:443'
+      },
+      url: '/about'
+    }
+
+    hostnamesHook(req, null, () => {
+      expect(req.url).to.equal('/about')
+      cb()
+    })
+  })
+})


### PR DESCRIPTION
```js
'use strict'

const gateway = require('../index')
const PORT = process.env.PORT || 8080
const http = require('http')
const restana = require('restana')

const hostnames2prefix = [{
  prefix: '/public',
  hostname: 'nodejs.org'
}]
const hostnamesHook = require('./../lib/hostnames-hook')(hostnames2prefix)

const app = restana()
const server = http.createServer((req, res) => {
  hostnamesHook(req, res, () => {
    return app(req, res)
  })
})

gateway({
  server: app,
  middlewares: [
  ],

  routes: [{
    prefix: '/public',
    target: 'http://localhost:3000'
  }]
})

server.listen(PORT)

const origin = require('restana')({})
origin
  .get('/hi', (req, res) => res.send('Hello World!'))
  .start(3000)
```