### PR TITLE
Adding url rewrite hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ module.exports.handler = serverless(service)
     },
     // Optional "prefix rewrite" before request is forwarded. Default value: ''
     prefixRewrite: '',
+    // Optional "url rewrite" hook. If defined, the prefixRewrite setting is ignored. 
+    urlRewrite: (req) => req.url,
     // Remote HTTP server URL to forward the request. 
     // If proxyType = 'lambda', the value is the name of the Lambda function, version, or alias.
     target: 'http://localhost:3000',

--- a/demos/url-rewrite.js
+++ b/demos/url-rewrite.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const gateway = require('../index')
+const PORT = process.env.PORT || 8080
+
+gateway({
+  routes: [{
+    pathRegex: '',
+    prefix: '/customers/:customerId',
+    target: 'http://localhost:3000',
+    urlRewrite: ({ params: { customerId } }) => `/users/${customerId}`
+  }]
+}).start(PORT).then(server => {
+  console.log(`API Gateway listening on ${PORT} port!`)
+})
+
+const service = require('restana')({})
+service
+  .get('/users/:id', (req, res) => res.send('Hello ' + req.params.id))
+  .start(3000).then(() => console.log('Service listening on 3000 port!'))

--- a/index.js
+++ b/index.js
@@ -91,7 +91,9 @@ const gateway = (opts) => {
 
 const handler = (route, proxy, proxyHandler) => async (req, res, next) => {
   try {
-    req.url = req.url.replace(route.prefix, route.prefixRewrite)
+    req.url = route.urlRewrite
+      ? route.urlRewrite(req)
+      : req.url.replace(route.prefix, route.prefixRewrite)
     const shouldAbortProxy = await route.hooks.onRequest(req, res)
     if (!shouldAbortProxy) {
       const proxyOpts = Object.assign({

--- a/test/config.js
+++ b/test/config.js
@@ -69,7 +69,7 @@ module.exports = async () => {
     {
       pathRegex: '',
       prefix: '/endpoint-proxy-methods',
-      prefixRewrite: '/endpoint-proxy-methods',
+      urlRewrite: (req) => '/endpoint-proxy-methods',
       target: 'http://localhost:3000',
       methods: ['GET', 'POST']
     },


### PR DESCRIPTION
```js
'use strict'

const gateway = require('../index')
const PORT = process.env.PORT || 8080

gateway({
  routes: [{
    pathRegex: '',
    prefix: '/customers/:customerId',
    target: 'http://localhost:3000',
    urlRewrite: ({ params: { customerId } }) => `/users/${customerId}`
  }]
}).start(PORT).then(server => {
  console.log(`API Gateway listening on ${PORT} port!`)
})

const service = require('restana')({})
service
  .get('/users/:id', (req, res) => res.send('Hello ' + req.params.id))
  .start(3000).then(() => console.log('Service listening on 3000 port!'))


```